### PR TITLE
Set up sane example only configuration

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -52,12 +52,12 @@
 
 global {
     // required tokens
-    name    not.configured;     # The IRC name of the server
-    info    "located on earth"; # A short info line
+    name    irc.examplebahamut.com;     # The IRC name of the server
+    info    "Example Bahamut IRC Network"; # A short info line
 
     // optional tokens
-    dpass   secret;             # Password for DIE command
-    rpass   secret;             # Password for RESTART command
+    dpass   rOq.H5>bgF-=P0Ik{OH;F0CisO`i(%;             # Password for DIE command
+    rpass   O8:zjaACgB_I::9xJt[1mvC!)Coz+-;             # Password for RESTART command
 
     // the optional Admin block may also be specified here
 };
@@ -87,9 +87,9 @@ global {
 
 admin {
     // optional tokens
-    "An unconfigured server";   # Info line #1
-    "An unknown administrator"; # Info line #2
-    "email@somewhere.earth";    # Info line #3
+    "An example bahamut server";   # Info line #1
+    "An example bahamut administrator"; # Info line #2
+    "email not available, please /join #help for assistance";    # Info line #3
 };
 
 # Not all lines are required.  There may be only one Admin block.
@@ -106,27 +106,27 @@ admin {
 
 options {
     // optional tokens
-    network_name    unconfigured;   # Name of the network
-    services_name   services.name;  # IRC name of services server
-    stats_name      stats.name;     # IRC name of stats server
-    staff_address   staff.net;      # Opermask hostname
-    nshelpurl       "http://foo";   # URL for nick registration help
-    spamfilterurl   "http://foo";   # URL for spamfilter help
-    wgmonhost       wgmon.host;     # Wingate monitor scan host
-    wgmonurl        "http://foo";   # URL for wingate monitor info
-    network_kline   "kline@net";    # Contact email for network bans
-    local_kline     "kline@server"; # Contact email for server bans
+    network_name    ExampleBahamut;   # Name of the network
+    services_name   services.examplebahamut.com;  # IRC name of services server
+    stats_name      services.examplebahamut.com;     # IRC name of stats server
+    staff_address   staff.examplebahamut.com;      # Opermask hostname
+    nshelpurl       "";   # URL for nick registration help
+    spamfilterurl   "";   # URL for spamfilter help
+    wgmonhost       wgmon.localhost;     # Wingate monitor scan host
+    wgmonurl        "";   # URL for wingate monitor info
+    network_kline   "kline@examplebahamut.com";    # Contact email for network bans
+    local_kline     "kline@examplebahamut.com"; # Contact email for server bans
     servtype        client;         # Set server type:
                                     #     CLIENT, HUB, SERVICESHUB
-    maxchannels     10;             # Max chans user can join
+    maxchannels     30;             # Max chans user can join
     ts_max_delta    300;            # Maximum timestamp delta
     ts_warn_delta   30;             # Warn for TS deltas larger than this
-    local_clones    1:15;           # Default maximum local IP:site clones
-    global_clones   3:30;           # Default maximum global IP:site clones
+    local_clones    3;           # Default maximum local IP:site clones
+    global_clones   3;           # Default maximum global IP:site clones
     crypt_oper_pass;                # Encrypted passwords in Oper blocks
     short_motd;                     # Use ircd.smotd
     show_links;                     # Show real LINKS output
-    allow_split_ops;                # Op in empty channels while unlinked
+    allow_split_ops;                # Op in empty channels while unlinked; REMOVE IF MORE THAN A SINGLE BAHAMUT INSTANCE IS IN USE
     allow_remote_rehash;            # Accept rehash sent from remote server
 };
 
@@ -225,9 +225,30 @@ port {
     port    6667;       # Port to listen on
 
     // optional tokens
-    bind    127.0.0.1;  # IP address to listen on
-    ipmask  127.0.*.*;  # Mask to accept connections from
-    flags   S;		# Allow SSL connections on this port
+    bind    *;  # IP address to listen on
+    ipmask  *;  # Mask to accept connections from
+    #flags   S;		# Allow SSL connections on this port
+};
+
+port {
+    port    6697;
+    bind    *;
+    ipmask  *;
+    flags S;
+};
+
+port {
+    port    7001; # Port for servers should be seperate from clients
+    bind    127.0.0.1;
+    ipmask  127.0.0.1;
+    flags i;
+};
+
+port {
+    port    7005; # Port for SSL server links should be seperate from clients
+    bind    127.0.0.1;
+    ipmask  127.0.0.1;
+    flags Si;
 };
 
 # If a bind address is not specified, the server listens on all available
@@ -263,13 +284,39 @@ class {
     maxsendq    100000;     # Send buffer limit
 
     // optional, for Allow classes only:
-    maxusers    100;        # Maximum number of clients
-    maxclones   2:20;       # Maximum IP:site clones
-    maxrecvq    2560;       # client excess flood threshold
+    maxusers    100000;        # Maximum number of clients
+    maxclones   3;       # Maximum IP:site clones
+    maxrecvq    8192;       # client excess flood threshold
 
     // optional, for Connect classes only:
-    connfreq    300;        # Try autoconnect every N seconds
-    maxlinks    1;          # Autoconnect if less than N links in class
+    #connfreq    300;        # Try autoconnect every N seconds
+    #maxlinks    1;          # Autoconnect if less than N links in class
+};
+
+class {
+    name opers;
+    pingfreq 90;
+    maxsendq 1000000:
+    maxusers 100;
+    maxclones 10;
+    maxrecvq 24576;
+};
+
+class {
+    name localhost;
+    pingfreq 90;
+    maxsendq 100000;
+    maxusers 100;
+    maxclones 100;
+    maxrecq 8192;
+};
+
+class {
+    name servers;
+    pingfreq 90;
+    maxsendq 10000000;
+    connfreq 300;
+    maxlinks 1;
 };
 
 # Idle connections are polled with the PING command every pingfreq seconds.
@@ -327,14 +374,32 @@ class {
 #     I:ipmask:passwd:host:port:class
 
 allow {
+    host localhost;
+    flags mCFT;
+    class localhost;
+    };
+    
+    allow {
+    ipmask 127.0.0.1;
+    flags mCFT;
+    class localhost;
+    };
+    
+    allow {
+    ipmask 0::1;
+    flags mCFT;
+    class localhost;
+    };
+
+allow {
     // required tokens
     host        *;          # Resolved host mask (optional if using ipmask)
     ipmask      *;          # Unresolved IP mask (optional if using host)
     
     // optional tokens
-    port        6667;       # Apply block to this port only
-    passwd      secret;     # Require password for connection
-    flags       mCFT;       # Special flags for this connection
+    #port        6667;       # Apply block to this port only
+    #passwd      secret;     # Require password for connection
+    #flags       mCFT;       # Special flags for this connection
     class       users;      # Place connections in this class
 };
 
@@ -448,13 +513,15 @@ allow {
 
 oper {
     // required tokens
-    name    johndoe;        # Account name
-    passwd  secret;         # Account password (optionally encrypted)
-    host    ident@hostmask; # Restrict access to this mask
-    host    *@172.16.4.2;   # Up to 32 masks can be specified here
-    access  *Aa;            # Access flags
+    name    ExampleBahamutAdmin;        # Account name
+    passwd   O1pH,FL-ENS{JT0dl9auRhVjy#RZc9;  #DO NOT USE, MAKE OWN WITH tools/mkpasswd
+    host    *@localhost; # Restrict access to this mask
+    host    *@127.0.0.1;   # Up to 32 masks can be specified here
+    host    *@0::1;
+    access  OaFRA;            # Access flags
 
     // optional tokens
+    crypt_oper_pass;
     class   opers;          # Place authenticated client in this class
 };
 
@@ -524,15 +591,15 @@ oper {
 
 connect {
     // required tokens
-    name    server.name;    # Other server's name
-    host    server.host;    # Other server's host
+    name    services.eamplebahamut.com;    # Other server's name
+    host    127.0.0.1;    # Other server's host
     apasswd secret;         # Password to accept from other server
     cpasswd secret;         # Password to send to other server
 
     // optional tokens
-    port    7000;           # Port to autoconnect to other server on
+    #port    7005;           # Port to autoconnect to other server on; not used for services as they connect to IRCd not vice versa
     bind    127.0.0.1;      # IP to connect from
-    flags   ZEH;            # Flags for this link
+    flags   ZE;            # Flags for this link
     class   servers;        # Connection class to use for this link
 };
 
@@ -572,8 +639,8 @@ connect {
 #     U:name:*:*
 
 super {
-    "server1.name";     # Super server #1
-    "server2.name";     # Super server #2
+    "services.examplebahamut.com";     # Super server #1
+    #"server2.name";     # Super server #2
                         # ...
 };
 


### PR DESCRIPTION
Server, Admin etc information must of course still be adapted to the respective network as other aspects as well. This was done so some more sane defaults can be applied (e.g. adding the referenced yet missing opers and servers classes) and so defaults no longer specify DALnet to prevent impersonation and confusion.